### PR TITLE
import chocolatey helpers to make refreshenv available in powershell

### DIFF
--- a/windows-2022-bolt/Vagrantfile
+++ b/windows-2022-bolt/Vagrantfile
@@ -14,7 +14,10 @@ choco install ruby
 
 choco install msys2
 
-Update-SessionEnvironment
+# import chocolatey helpers to make refreshenv available in powershell
+# copied from https://github.com/actions/runner-images/discussions/6065
+Import-Module "$env:ChocolateyInstall/helpers/chocolateyInstaller.psm1"
+refreshenv
 
 ridk install 3
 


### PR DESCRIPTION
This fixes the error:

```
Update-SessionEnvironment : The term 'Update-SessionEnvironment' is not recognized as the name of a cmdlet, function,
script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is
correct and try again.
At C:\tmp\vagrant-shell.ps1:13 char:1
+ Update-SessionEnvironment
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Update-SessionEnvironment:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```